### PR TITLE
fix: Tooltip 이중 이벤트 중첩 버그 수정 및 내부 icon 기본 경로 추가

### DIFF
--- a/src/app/client-layout.tsx
+++ b/src/app/client-layout.tsx
@@ -4,7 +4,9 @@ import dynamic from "next/dynamic";
 import clsx from "clsx";
 import { usePathname } from "next/navigation";
 
-const NavBar = dynamic(() => import("@/components/ui/NavBar"), { ssr: false });
+const NavBar = dynamic(() => import("@/components/ui/NavBar"), {
+  ssr: false
+});
 const Tooltip = dynamic(() => import("@/components/ui/Tooltip"), {
   ssr: false
 });

--- a/src/app/reviews/[id]/components/CommentSection.tsx
+++ b/src/app/reviews/[id]/components/CommentSection.tsx
@@ -169,7 +169,7 @@ export default function CommentSection({
       }
       setHasContent(false);
 
-      showTooltip("댓글이 등록되었습니다.", "/images/icon/ic_check.svg");
+      showTooltip("댓글이 등록되었습니다.");
     } catch (error) {
       console.error("댓글 작성 실패:", error);
       alert("댓글 작성에 실패했습니다. 다시 시도해주세요.");

--- a/src/components/common/NavProfile.tsx
+++ b/src/components/common/NavProfile.tsx
@@ -2,10 +2,10 @@
 
 import { useDisclosure } from "@/hooks/common/useDisclosure";
 import clsx from "clsx";
-import Modal from "./Modal";
 import { Dispatch, SetStateAction, useEffect } from "react";
 import { useProfileActions } from "@/hooks/profile/useProfileActions";
 import { useTooltipStore } from "@/store/tooltipStore";
+import Modal from "../ui/Modal";
 
 export default function NavProfile({
   userId,

--- a/src/components/ui/NavBar.tsx
+++ b/src/components/ui/NavBar.tsx
@@ -7,7 +7,7 @@ import { useClickOutside } from "@/hooks/common/useClickOutside";
 import { useAuthStore } from "@/store/authStore";
 import { useEffect, useState } from "react";
 import { authApi } from "@/api/auth";
-import NavProfile from "./NavProfile";
+import NavProfile from "../common/NavProfile";
 
 export default function NavBar() {
   const [mounted, setMounted] = useState(false);

--- a/src/store/tooltipStore.ts
+++ b/src/store/tooltipStore.ts
@@ -4,21 +4,26 @@ import { persist } from "zustand/middleware";
 interface TooltipState {
   isVisible: boolean;
   content: string;
-  icon?:string;
-  showTooltip: (content: string, icon?:string) => void;
+  icon?: string;
+  showTooltip: (content: string, icon?: string) => void;
   hideTooltip: () => void;
 }
+
+let tooltipTimeout: NodeJS.Timeout;
 
 export const useTooltipStore = create<TooltipState>()(
   persist(
     set => ({
       isVisible: false,
       content: "",
-      icon:undefined,
+      icon: undefined,
+
       showTooltip: (content, icon, duration = 3000) => {
         set({ isVisible: true, content, icon });
 
-        setTimeout(() => {
+        if (tooltipTimeout) clearTimeout(tooltipTimeout);
+
+        tooltipTimeout = setTimeout(() => {
           set({ isVisible: false });
         }, duration);
       },

--- a/src/store/tooltipStore.ts
+++ b/src/store/tooltipStore.ts
@@ -19,7 +19,11 @@ export const useTooltipStore = create<TooltipState>()(
       icon: undefined,
 
       showTooltip: (content, icon, duration = 3000) => {
-        set({ isVisible: true, content, icon });
+        set({
+          isVisible: true,
+          content,
+          icon: icon ?? "/images/icon/ic_check.svg"
+        });
 
         if (tooltipTimeout) clearTimeout(tooltipTimeout);
 


### PR DESCRIPTION
## ✨ What’s Changed?

- Tooltip 연속 호출 시 이벤트 중첩 되어 툴팁이 정상적으로 출력되지 않는 버그 수정
- Tooltip 내부 아이콘 기본 경로 추가하였으므로 사용에 참고 바랍니다. (병진님 작업분 중 CommentSection.tsx의 showTooltip("댓글이 등록되었습니다."); 도 수정해서 pr 올림)

ex) 사용법
1. [경고 툴팁]
showTooltip("파일 용량을 확인해주세요.", "/images/icon/ic_exclamation-circle.svg");

2.[안내 툴팁]
showTooltip("댓글이 등록되었습니다.")

## 📸 Screenshots

<img width="1228" height="1145" alt="스크린샷 2025-09-27 오후 12 36 45" src="https://github.com/user-attachments/assets/4b9003f5-2b02-4cef-84db-ec0ed9a466dd" />
<img width="1222" height="1144" alt="스크린샷 2025-09-27 오후 12 36 57" src="https://github.com/user-attachments/assets/a2cf0f55-bd54-4460-a3c9-7384e35a442c" />
