### PR TITLE
fix: 도서/리뷰 목록 페이지 - 사용자 경험 향상을 위한 UIUX 수정

### DIFF
--- a/src/app/client-layout.tsx
+++ b/src/app/client-layout.tsx
@@ -32,7 +32,7 @@ export default function ClientLayout({
       <div
         className={clsx(
           !hideNavigation &&
-            "min-h-[calc(100vh-67px)] mt-[67px] px-4 max-w-[1200px] mx-auto"
+            "min-h-[calc(100vh-139px)] mt-[67px] px-4 max-w-[1200px] mx-auto"
         )}
       >
         {children}

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -82,7 +82,7 @@ export default function ReviewsPage() {
   }
 
   return (
-    <div className="pt-[50px] pb-[80px]">
+    <div className="pt-[50px] pb-[80px] h-[inherit] min-h-[inherit] flex flex-col">
       <div className="flex mb-5 py-[6px] text-header1 font-bold text-[#111827]">
         리뷰 리스트
       </div>

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -57,6 +57,7 @@ const SearchBar = memo(
           inputRef.current.value = "";
         }
         onClear?.();
+        onSearch?.("");
       };
 
       // 엔터키 핸들러


### PR DESCRIPTION
## ✨ What’s Changed?

- 도서/리뷰 목록 Empty UI 출력 시 중앙 정렬 (footer가 추가 되어 불필요한 스크롤을 막기 위해 client-layout.tsx의 전체 높이 조정 추가)
- 검색창 'X' 버튼 클릭 시 검색어만 초기화되던 문제 수정 (데이터도 함께 초기화되도록 변경하여 전체 목록이 즉시 보이도록 개선)

## 📸 Screenshots

![화면 기록 2025-09-27 오후 12 58 40](https://github.com/user-attachments/assets/f152003f-cdbb-4851-83d0-3b8df03ab5d9)
