### PR TITLE
fix: 알림 컴포넌트 404/500 에러 상황 튤팁 추가

### DIFF
--- a/src/components/ui/Notifications/Notification.tsx
+++ b/src/components/ui/Notifications/Notification.tsx
@@ -167,7 +167,6 @@ export default function Notification({
         onNotificationRead?.();
       }
 
-      // 리뷰 존재 여부 확인 (Next.js 에러 바운더리로 전파되지 않도록 fetch 사용)
       try {
         const authState = useAuthStore.getState();
         const response = await fetch(`/api/reviews/${notification.reviewId}`, {
@@ -224,7 +223,6 @@ export default function Notification({
           const target = e.target as HTMLDivElement;
           const { scrollTop, scrollHeight, clientHeight } = target;
 
-          // 스크롤이 하단 근처에 도달했을 때 더 많은 데이터 로드
           if (scrollTop + clientHeight >= scrollHeight - 100) {
             fetchMoreNotifications();
           }


### PR DESCRIPTION
## ✨ What’s Changed?

- 알림목록 404/500 에러 상황 튤팁 추가.

* 스웨거 api상 알림 목록 조회는 이미 없는 알림(좋아요 취소, 리뷰/댓글 삭제)도 보내주기에
해당알림 클릭시 404/500 에러는 사용자에게 튤팁을 제공하는 방법을 택했습니다.

## 📸 Screenshots

-

https://github.com/user-attachments/assets/f2fa0fc4-7570-4cd2-89a3-bf51971283e0


